### PR TITLE
add auto-shrink system for tabs

### DIFF
--- a/mods/core/tabs.css
+++ b/mods/core/tabs.css
@@ -104,6 +104,17 @@ body,
 }
 #tabs {
   margin-top: auto;
+  flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+}
+#tabs .tab:not(.new):not(.current) {
+  flex: 1 1 60px;
+  min-width: 60px;
+}
+#tabs button:nth-child(17) {
+  display: none;
+  opacity: 0;
 }
 #tabs .tab {
   display: inline-flex;
@@ -122,7 +133,7 @@ body,
   border-radius: 3px;
   margin: 0 0.5em -0.16em 0.1em;
 }
-#tabs .tab:first-child {
+#tabs .tab:not(.new) {
   margin-top: 0.5em;
 }
 #tabs .tab:not(.new) span:not(.close) {
@@ -153,6 +164,7 @@ body,
   background: none;
   border: none;
   margin-left: -0.1em;
+  margin-top: 0.3em;
 }
 #tabs .tab.new span {
   padding: 0 0.35em 0.1em 0.3em;

--- a/mods/core/tabs.css
+++ b/mods/core/tabs.css
@@ -109,10 +109,10 @@ body,
   align-items: center;
 }
 #tabs .tab:not(.new):not(.current) {
-  flex: 1 1 60px;
-  min-width: 60px;
+  flex: 1 1 30px;
+  min-width: 30px;
 }
-#tabs button:nth-child(17) {
+#tabs button:nth-child(16) {
   display: none;
   opacity: 0;
 }


### PR DESCRIPTION
these changes prevent the tabs section from wrapping. if the total width of all tabs is greater than the available width, non-current tabs are automatically shrink to prevent wrapping and make available space for new tabs.

up to ~~16~~ 15 tabs can be added, and after ~~16~~ 15 tabs have been added, the new tab adding button is removed. after a tab is removed, the add tab button returns. **take a look at this gif to see how this system works:**

![auto-shrink system gif](https://i.imgur.com/itOopOy.gif)