### PR TITLE
Add note about supported linux client versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ for support, join the [discord server](https://discord.gg/sFWPXtA).
 - [@haydn-jones](https://github.com/haydn-jones/)'s fork of the
   linux [notion-deb-builder](https://github.com/haydn-jones/notion-deb-builder).
 
+linux clients must use a notion version >= 2.0.8.
+
 mobile clients are not supported and due to system limitations/restrictions cannot be.
 
 a chrome extension may be coming soon for web client support.


### PR DESCRIPTION
Anything earlier than v2.0.8 is unsupported by notion enhancer and will not work. As both of the current linux clients listed in the README.md ([notion-app installer](https://github.com/jaredallard/notion-app) and [notion-deb-builder](https://github.com/haydn-jones/notion-deb-builder))  have their default set lower to this, it would be extremely valuable to the public to know this information.