### PR TITLE
Fix missing table and calendar borders.

### DIFF
--- a/mods/core/css/theme.css
+++ b/mods/core/css/theme.css
@@ -243,7 +243,7 @@
 }
 
 .notion-body.dark [style*='box-shadow: rgb(47, 52, 55) -3px 0px 0px'] {
-  box-shadow: var(--theme--main) -3px 0px 0px !important;
+  box-shadow: var(--theme--main) -3px 0px 0px, rgb(77, 81, 83) 0px 1px 0px !important;
 }
 .notion-body:not(.dark) [style*='box-shadow: white -3px 0px 0px;'] {
   box-shadow: none !important;
@@ -362,9 +362,6 @@
   [style*='min-width: 708px;'] {
   min-width: 100% !important;
 }
-.notion-page-content .notion-collection_view-block > div {
-  padding: 0 1px;
-}
 
 /* smooth transitions */
 .notion-calendar-view-day,
@@ -380,12 +377,6 @@
 }
 .notion-to_do-block > div > div > div[style*='background:'] {
   transition: background 200ms ease !important;
-}
-
-/* fix button resizing */
-.notion-collection_view-block [role='button'],
-.notion-collection_view_page-block [role='button'] {
-  border-width: 0 !important;
 }
 
 /** general ui **/

--- a/mods/core/css/theme.css
+++ b/mods/core/css/theme.css
@@ -243,7 +243,12 @@
 }
 
 .notion-body.dark [style*='box-shadow: rgb(47, 52, 55) -3px 0px 0px'] {
-  box-shadow: var(--theme--main) -3px 0px 0px, rgb(77, 81, 83) 0px 1px 0px !important;
+  box-shadow: var(--theme--main) -3px 0px 0px;
+}
+
+.notion-body.dark [style*='rgb(47, 52, 55) -3px 0px 0px, rgb(77, 81, 83) 0px 1px 0px'] {
+  box-shadow: var(--theme--main) -3px 0px 0px, var(--theme--table-border) 0px 1px 0px !important;
+/*  border-top: 1px solid var(--theme--table-border) !important;*/
 }
 .notion-body:not(.dark) [style*='box-shadow: white -3px 0px 0px;'] {
   box-shadow: none !important;

--- a/mods/tweaks/app.css
+++ b/mods/tweaks/app.css
@@ -90,10 +90,10 @@ div.notion-selectable.notion-numbered_list-block > div > div:last-child::before 
   opacity: 0.25;
 }
 
-[data-tweaks*='[scroll_db_toolbars]'] [style*='min-height: 42px; padding-left: 96px; padding-right: 96px; flex-shrink: 0; z-index: 1; overflow: visible;'] > :first-child {
+[data-tweaks*='[scroll_db_toolbars]'] .notion-collection_view-block > :first-child[style*='height: 42px;'] {
     overflow-x: auto !important;
 }
 
-[data-tweaks*='[scroll_db_toolbars]'] [style*='min-height: 42px; padding-left: 96px; padding-right: 96px; flex-shrink: 0; z-index: 1; overflow: visible;'] > :first-child::-webkit-scrollbar {
-    display: none;
+[data-tweaks*='[scroll_db_toolbars]'] .notion-collection_view-block > :first-child[style*='height: 42px;']::-webkit-scrollbar {
+  display: none;
 }

--- a/mods/tweaks/app.css
+++ b/mods/tweaks/app.css
@@ -90,11 +90,10 @@ div.notion-selectable.notion-numbered_list-block > div > div:last-child::before 
   opacity: 0.25;
 }
 
-[data-tweaks*='[scroll_db_toolbars]'] .notion-frame > .notion-scroller > [style*="overflow: visible;"],
-[data-tweaks*='[scroll_db_toolbars]'] .notion-page-content .notion-collection_view-block > :first-child {
+[data-tweaks*='[scroll_db_toolbars]'] [style*='min-height: 42px; padding-left: 96px; padding-right: 96px; flex-shrink: 0; z-index: 1; overflow: visible;'] > :first-child {
     overflow-x: auto !important;
 }
-[data-tweaks*='[scroll_db_toolbars]'] .notion-frame > .notion-scroller > [style*="overflow: visible;"]::-webkit-scrollbar,
-[data-tweaks*='[scroll_db_toolbars]'] .notion-page-content .notion-collection_view-block > :first-child::-webkit-scrollbar {
+
+[data-tweaks*='[scroll_db_toolbars]'] [style*='min-height: 42px; padding-left: 96px; padding-right: 96px; flex-shrink: 0; z-index: 1; overflow: visible;'] > :first-child ::-webkit-scrollbar {
     display: none;
 }

--- a/mods/tweaks/app.css
+++ b/mods/tweaks/app.css
@@ -94,6 +94,6 @@ div.notion-selectable.notion-numbered_list-block > div > div:last-child::before 
     overflow-x: auto !important;
 }
 
-[data-tweaks*='[scroll_db_toolbars]'] [style*='min-height: 42px; padding-left: 96px; padding-right: 96px; flex-shrink: 0; z-index: 1; overflow: visible;'] > :first-child ::-webkit-scrollbar {
+[data-tweaks*='[scroll_db_toolbars]'] [style*='min-height: 42px; padding-left: 96px; padding-right: 96px; flex-shrink: 0; z-index: 1; overflow: visible;'] > :first-child::-webkit-scrollbar {
     display: none;
 }


### PR DESCRIPTION
This solves #234 and #222. There is a missing variable for the horizontal bar color (`rgb(77, 81, 83)`), so I have left it in one of the `border-shadow`s and opened #280.
There is still an issue with the scrollable databases titles, where the fading animation of the draggable handle doesn't move with the block as it scrolls.