### PR TITLE
make app relaunch info alert sticky

### DIFF
--- a/mods/core/menu.css
+++ b/mods/core/menu.css
@@ -152,6 +152,8 @@ s {
   color: var(--theme--line_blue-text);
   background: var(--theme--line_blue);
   border-color: var(--theme--select_blue);
+  position: absolute;
+  z-index: 82;
 }
 #alerts .success::before {
   content: '✓';


### PR DESCRIPTION
The info alert for app relaunch is now sticky to the top of the options window.

However, the alert overlaps the search div when window scroll position is already at top.

For issue #290.