### PR TITLE
new extension: panel-sites

### DIFF
--- a/mods/panel-sites/app.css
+++ b/mods/panel-sites/app.css
@@ -1,0 +1,12 @@
+/*
+ * panel sites
+ * (c) 2020 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
+ * (c) 2020 CloudHill
+ * under the MIT license
+ */
+ 
+.panel-site {
+  border: none;
+  flex: 1;
+  background: white;
+}

--- a/mods/panel-sites/mod.js
+++ b/mods/panel-sites/mod.js
@@ -1,0 +1,28 @@
+/*
+ * panel sites
+ * (c) 2020 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
+ * (c) 2020 CloudHill
+ * under the MIT license
+ */
+
+'use strict';
+
+module.exports = {
+  id: '0d541743-eb2c-4d77-83a8-3b2f5e8e5dff',
+  tags: ['extension', 'panel'],
+  name: 'panel sites',
+  desc: 'embed sites on the site panel.',
+  version: '1.0.0',
+  author: 'CloudHill',
+  options: [
+    {
+      key: 'sites',
+      label: 'list of sites',
+      type: 'file',
+      extensions: ['json'],
+    },
+  ],
+  panel: {
+    js: 'panel.js'
+  }
+};

--- a/mods/panel-sites/panel.js
+++ b/mods/panel-sites/panel.js
@@ -1,0 +1,45 @@
+/*
+ * panel sites
+ * (c) 2020 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
+ * (c) 2020 CloudHill
+ * under the MIT license
+ */
+
+const electron = require('electron')
+
+module.exports = (store) => {
+  let iframe;
+  const mainWindow = electron.remote.getCurrentWindow();
+  const originalUserAgent = mainWindow.webContents.getUserAgent();
+  const mobileUserAgent = 
+    'Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36'
+
+  // bypass x-frame-options 
+  mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    const responseHeaders = Object.entries(details.responseHeaders)
+      .filter( h => !/x-frame-options/i.test(h[0]) );
+    callback({
+      responseHeaders: Object.fromEntries(responseHeaders)
+    });
+  });
+
+  // handle opening mobile sites
+  function setUserAgent(userAgent) {
+    mainWindow.webContents.session.webRequest.onBeforeSendHeaders((details, callback) => {
+      details.requestHeaders['User-Agent'] = userAgent;
+      callback({ cancel: false, requestHeaders: details.requestHeaders });
+    });
+  }
+
+  return {
+    onLoad() {
+      iframe = document.querySelector('.panel-site');
+      if (iframe.hasAttribute('mobile-user-agent'))
+        setUserAgent(mobileUserAgent);
+    },
+    onSwitch() {
+      if (iframe.hasAttribute('mobile-user-agent'))
+        setUserAgent(originalUserAgent);
+    }
+  }
+}


### PR DESCRIPTION
embed sites into the side panel extension.

![image](https://cdn.discordapp.com/attachments/748162550910287922/781177969523032112/planets-cuz-planets.gif)

## defining your site list

users should provide a `json` file containing an array of `site` objects.

a site object can have the following properties:

| property |  description | type |
| ---------- | ------------ | ---- |
| `name` | the name that will be displayed on the panel switcher | string |
| `url`      | the url of the site | string |
| `icon` (optional) | a url pointing to an image file (local images not supported) | string |
| `mobile` (optional) | set to `true` to use a mobile user agent (this loads the mobile version of some sites) | boolean |

**not all sites will work. the login process for some sites will be hit-or-miss. this is due to limitations of the `iframe` tag and cross-origin restrictions.**

### example

this is an example of a valid `json` file which contains two sites: Google and Todoist :

```json
[
  {
    "name": "Google",
    "url": "google.com",
    "mobile": true
  },
  {
    "name": "Todoist",
    "url": "todoist.com"
  }
]
```