### PR TITLE
add quote variable for themes and quote input for font chooser

### DIFF
--- a/mods/core/css/theme.css
+++ b/mods/core/css/theme.css
@@ -4,6 +4,7 @@
  * (c) 2020 TarasokUA
  * (c) 2020 Arecsu
  * (c) 2020 u/zenith_illinois
+ * (c) 2020 admiraldus (https://github.com/admiraldus)
  * under the MIT license
  */
 
@@ -144,6 +145,9 @@
 }
 [style*='SFMono-Regular'] {
   font-family: var(--theme--font_code) !important;
+}
+.notion-selectable.notion-quote-block div[spellcheck="true"] {
+  font-family: var(--theme--font_quote) !important;	
 }
 .notion-frame .notion-page-block div[placeholder='Untitled'],
 .notion-overlay-container .notion-page-block div[placeholder='Untitled'] {

--- a/mods/core/variables.css
+++ b/mods/core/variables.css
@@ -4,6 +4,7 @@
  * (c) 2020 TarasokUA
  * (c) 2020 Arecsu
  * (c) 2020 u/zenith_illinois
+ * (c) 2020 admiraldus (https://github.com/admiraldus)
  * under the MIT license
  */
 
@@ -35,6 +36,7 @@
   --theme_dark--font_mono: iawriter-mono, Nitti, Menlo, Courier, monospace;
   --theme_dark--font_code: SFMono-Regular, Consolas, 'Liberation Mono', Menlo,
     Courier, monospace;
+  --theme_dark--font_quote: var(--theme_dark--font_sans);
 
   --theme_dark--font_title-size: 40px;
   --theme_dark--font_heading1-size: 1.875em;
@@ -219,6 +221,7 @@
   --theme_light--font_mono: iawriter-mono, Nitti, Menlo, Courier, monospace;
   --theme_light--font_code: SFMono-Regular, Consolas, 'Liberation Mono', Menlo,
     Courier, monospace;
+  --theme_light--font_quote: var(--theme_light--font_sans);
 
   --theme_light--font_title-size: 40px;
   --theme_light--font_heading1-size: 1.875em;
@@ -396,6 +399,7 @@
   --theme--font_serif: var(--theme_dark--font_serif);
   --theme--font_mono: var(--theme_dark--font_mono);
   --theme--font_code: var(--theme_dark--font_code);
+  --theme--font_quote: var(--theme_dark--font_sans);
   --theme--font_title-size: var(--theme_dark--font_title-size);
   --theme--font_heading1-size: var(--theme_dark--font_heading1-size);
   --theme--font_heading2-size: var(--theme_dark--font_heading2-size);
@@ -562,6 +566,7 @@
   --theme--font_serif: var(--theme_light--font_serif);
   --theme--font_mono: var(--theme_light--font_mono);
   --theme--font_code: var(--theme_light--font_code);
+  --theme--font_quote: var(--theme_light--font_sans);
   --theme--font_title-size: var(--theme_light--font_title-size);
   --theme--font_heading1-size: var(--theme_light--font_heading1-size);
   --theme--font_heading2-size: var(--theme_light--font_heading2-size);

--- a/mods/font-chooser/mod.js
+++ b/mods/font-chooser/mod.js
@@ -2,6 +2,7 @@
  * font chooser
  * (c) 2020 torchatlas (https://bit.ly/torchatlas)
  * (c) 2020 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
+ * (c) 2020 admiraldus (https://github.com/admiraldus)
  * under the MIT license
  */
 
@@ -12,8 +13,8 @@ module.exports = {
   tags: ['extension'],
   name: 'font chooser',
   desc:
-    'customize fonts. for each option, type in the name of the font you would like to use, or leave it blank to not change anything.',
-  version: '0.1.1',
+    'customize fonts. for each option, type in the name of the font you would like to use, or leave it blank to not change anything.<br/><br/>make sure the fonts you type are installed on your device.',
+  version: '0.1.2',
   author: 'torchatlas',
   options: [
     {
@@ -40,6 +41,12 @@ module.exports = {
       type: 'input',
       value: '',
     },
+    {
+      key: 'quote',
+      label: 'quote:',
+      type: 'input',
+      value: '',
+    },
   ],
   hacks: {
     'renderer/preload.js'(store, __exports) {
@@ -47,7 +54,7 @@ module.exports = {
       async function enhance() {
         if (!document.querySelector('.notion-app-inner')) return;
         clearInterval(attempt_interval);
-        for (let style of ['sans', 'serif', 'mono', 'code']) {
+        for (let style of ['sans', 'serif', 'mono', 'code', 'quote']) {
           if (!store()[style]) continue;
           document
             .querySelector('.notion-app-inner')

--- a/mods/font-chooser/mod.js
+++ b/mods/font-chooser/mod.js
@@ -14,7 +14,7 @@ module.exports = {
   name: 'font chooser',
   desc:
     'customize fonts. for each option, type in the name of the font you would like to use, or leave it blank to not change anything.<br/><br/>make sure the fonts you type are installed on your device.',
-  version: '0.1.2',
+  version: '0.2.1',
   author: 'torchatlas',
   options: [
     {


### PR DESCRIPTION
- new quote variable for themes:
  - **`--theme_dark--font_quote`**
  - **`--theme_light--font_quote`**
- changes on @TorchAtlas's font chooser:
  - added a warning saying that the desired fonts must be installed on the device.
    - **`make sure the fonts you type are installed on your device.`**
  - added a new input to change the font of quotes.
  - version number: **`0.1.1`** -> ~~**`0.1.2`**~~ **`0.2.1`**.

#### images:
![IMG](https://i.imgur.com/WvSLjHP.png)
![IMG](https://i.imgur.com/aXV3rrY.png)
![IMG](https://i.imgur.com/XuUECGW.png)