### PR TITLE
option: hide 'page details' text for word counter

### DIFF
--- a/mods/word-counter/mod.js
+++ b/mods/word-counter/mod.js
@@ -15,7 +15,7 @@ module.exports = {
   name: 'word counter',
   desc:
     'add page details: word/character/sentence/block count & speaking/reading times.',
-  version: '0.1.0',
+  version: '0.2.0',
   author: 'dragonwocky',
   options: [
     {

--- a/mods/word-counter/mod.js
+++ b/mods/word-counter/mod.js
@@ -19,7 +19,7 @@ module.exports = {
   author: 'dragonwocky',
   options: [
     {
-      key: 'hidePageDetailsText',
+      key: 'hide_page_details_text',
       label: 'hide "page details" text',
       type: 'toggle',
       value: false,
@@ -108,7 +108,7 @@ module.exports = {
           ];
 
           $container.children[0].innerHTML = `
-            ${store().hidePageDetailsText ? '' : '<span><b>page details<br></b> (click to copy)</span>'}
+            ${store().hide_page_details_text ? '' : '<span><b>page details<br></b> (click to copy)</span>'}
             ${Object.keys(details).reduce(
               (prev, key) =>
                 prev +

--- a/mods/word-counter/mod.js
+++ b/mods/word-counter/mod.js
@@ -1,6 +1,7 @@
 /*
  * word counter
  * (c) 2020 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
+ * (c) 2020 admiraldus (https://github.com/admiraldus)
  * under the MIT license
  */
 
@@ -16,6 +17,14 @@ module.exports = {
     'add page details: word/character/sentence/block count & speaking/reading times.',
   version: '0.1.0',
   author: 'dragonwocky',
+  options: [
+    {
+      key: 'hidePageDetailsText',
+      label: 'hide "page details" text',
+      type: 'toggle',
+      value: false,
+    },
+  ],
   hacks: {
     'renderer/preload.js'(store, __exports) {
       const copyToClipboard = (str) => {
@@ -99,7 +108,7 @@ module.exports = {
           ];
 
           $container.children[0].innerHTML = `
-            <span><b>page details<br></b> (click to copy)</span>
+            ${store().hidePageDetailsText ? '' : '<span><b>page details<br></b> (click to copy)</span>'}
             ${Object.keys(details).reduce(
               (prev, key) =>
                 prev +


### PR DESCRIPTION
- added a new toggle to hide 'page details' text.
- version number: **`0.1.0`** -> **`0.2.0`**.

#### images:
![IMG](https://i.imgur.com/7uXEZKZ.png)
![IMG](https://i.imgur.com/C6nUAIE.png)