### PR TITLE
fix the sizing of avatars in enhancer menu

### DIFF
--- a/mods/core/menu.css
+++ b/mods/core/menu.css
@@ -1,6 +1,7 @@
 /*
  * notion-enhancer
  * (c) 2020 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
+ * (c) 2020 admiraldus (https://github.com/admiraldus)
  * under the MIT license
  */
 
@@ -298,12 +299,13 @@ s {
   color: currentColor;
 }
 #modules section .author img {
-  max-height: 1em;
-  max-width: 1em;
+  height: 1em;
+  width: 1em;
   margin-bottom: 0.15625em;
   display: inline-block;
   vertical-align: middle;
   border-radius: 50%;
+  object-fit: cover;
 }
 #modules section .tags,
 #modules section .version {


### PR DESCRIPTION
**problem:** if the avatar is not a perfect square, it takes the shape of an ellipse rather than a square.
- the width and height values of all avatars are fixed to 1em
- avatars now take the shape of a perfect square

<table border="0">
 <tr>
    <td><i>before</i></td>
    <td><i>after</i></td>
 </tr>
 <tr>
    <td><img alt="before" src="https://i.imgur.com/Pcc4PdW.png"></td>
    <td><img alt="after" src="https://i.imgur.com/QC3PaGX.png"></td>
 </tr>
</table>