### PR TITLE
Support isolated installations

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/bin.js
+++ b/bin.js
@@ -24,30 +24,37 @@ cli.option('-n, --no', ': skip prompts (may cause failures)');
 cli.option('-d, --dev', ': show detailed error messages (for debug purposes)');
 
 cli
-  .command('apply', ': add the enhancer to the notion app')
-  .action(async (options) => {
+  .command('apply <path>', ': add the enhancer to the notion app')
+  .action(async (path, options) => {
     console.info('=== NOTION ENHANCEMENT LOG ===');
     await require('./pkg/apply.js')({
+      __notion: path,
       overwrite_version: options.yes ? 'y' : options.no ? 'n' : undefined,
       friendly_errors: !options.dev,
     });
     console.info('=== END OF LOG ===');
   });
 cli
-  .command('remove', ': return notion to its pre-enhanced/pre-modded state')
-  .action(async (options) => {
+  .command(
+    'remove <path>',
+    ': return notion to its pre-enhanced/pre-modded state'
+  )
+  .action(async (path, options) => {
     console.info('=== NOTION RESTORATION LOG ===');
     await require('./pkg/remove.js')({
+      __notion: path,
       delete_data: options.yes ? 'y' : options.no ? 'n' : undefined,
       friendly_errors: !options.dev,
     });
     console.info('=== END OF LOG ===');
   });
 cli
-  .command('check', ': check the current state of the notion app')
-  .action(async (options) => {
+  .command('check <path>', ': check the current state of the notion app')
+  .action(async (path, options) => {
     try {
-      const status = await require('./pkg/check.js')();
+      const status = await require('./pkg/check.js')({
+        __notion: path,
+      });
       console.info(options.dev ? status : status.msg);
     } catch (err) {
       console.error(

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "notion-enhancer": "bin.js"
   },
   "scripts": {
-    "test": "echo \"no test specified\"",
-    "postinstall": "node bin.js apply -y",
-    "preuninstall": "node bin.js remove -n"
+    "test": "echo \"no test specified\""
   },
   "repository": {
     "type": "git",

--- a/pkg/apply.js
+++ b/pkg/apply.js
@@ -128,7 +128,7 @@ module.exports = async function ({ overwrite_version, friendly_errors } = {}) {
           if (err) throw err;
           fs.writeFile(
             insertion_file,
-            `${data
+            data
               .replace(
                 /process.platform === "win32"/g,
                 'process.platform === "win32" || process.platform === "linux"'
@@ -136,21 +136,18 @@ module.exports = async function ({ overwrite_version, friendly_errors } = {}) {
               .replace(
                 /else \{[\s\n]+const win = createWindow_1\.createWindow\(relativeUrl\);/g,
                 'else if (relativeUrl) { const win = createWindow_1.createWindow(relativeUrl);'
-              )}\n\n//notion-enhancer\nrequire('${realpath(
-              __dirname
-            )}/loader.js')(__filename, exports);`,
+              ),
             'utf8',
             (err) => {
               if (err) throw err;
             }
           );
         });
-      } else {
-        fs.appendFile(
-          insertion_file,
-          `\n\n//notion-enhancer\nrequire('notion-enhancer/pkg/loader.js')(__filename, exports);`
-        );
       }
+      fs.appendFile(
+        insertion_file,
+        `\n\n//notion-enhancer\nrequire('notion-enhancer/pkg/loader.js')(__filename, exports);`
+      );
     }
 
     // not resolved, nothing else in apply process depends on it

--- a/pkg/apply.js
+++ b/pkg/apply.js
@@ -10,7 +10,7 @@ const fs = require('fs-extra'),
   path = require('path'),
   { readdirIterator } = require('readdir-enhanced'),
   { extractAll } = require('asar'),
-  { readline, getNotionResources } = require('./helpers.js'),
+  { readline } = require('./helpers.js'),
   { version } = require('../package.json');
 
 // === title ===
@@ -21,11 +21,14 @@ const fs = require('fs-extra'),
 //  ~~ exit
 // ### error ###
 
-module.exports = async function ({ overwrite_version, friendly_errors } = {}) {
-  const __notion = getNotionResources();
+module.exports = async function ({
+  __notion,
+  overwrite_version,
+  friendly_errors,
+} = {}) {
   try {
     // handle pre-existing installations: app.asar present? version set in data folder? overwrite?
-    const check_app = await require('./check.js')();
+    const check_app = await require('./check.js')({ __notion });
     switch (check_app.code) {
       case 1:
         throw Error(check_app.msg);
@@ -55,6 +58,7 @@ module.exports = async function ({ overwrite_version, friendly_errors } = {}) {
         );
         if (
           !(await require('./remove.js')({
+            __notion,
             delete_data: 'n',
             friendly_errors,
           }))

--- a/pkg/apply.js
+++ b/pkg/apply.js
@@ -148,9 +148,7 @@ module.exports = async function ({ overwrite_version, friendly_errors } = {}) {
       } else {
         fs.appendFile(
           insertion_file,
-          `\n\n//notion-enhancer\nrequire('${realpath(
-            __dirname
-          )}/loader.js')(__filename, exports);`
+          `\n\n//notion-enhancer\nrequire('notion-enhancer/pkg/loader.js')(__filename, exports);`
         );
       }
     }

--- a/pkg/apply.js
+++ b/pkg/apply.js
@@ -152,6 +152,12 @@ module.exports = async function ({
       );
     }
 
+    // copy notion-enhancer into node_modules
+    await fs.copy(
+      `${__dirname}/..`,
+      `${__notion}/app/node_modules/notion-enhancer`
+    );
+
     // not resolved, nothing else in apply process depends on it
     // so it's just a "let it do its thing"
     console.info(' ...recording enhancement version.');

--- a/pkg/apply.js
+++ b/pkg/apply.js
@@ -10,7 +10,7 @@ const fs = require('fs-extra'),
   path = require('path'),
   { readdirIterator } = require('readdir-enhanced'),
   { extractAll } = require('asar'),
-  { readline, realpath, getNotionResources } = require('./helpers.js'),
+  { readline, getNotionResources } = require('./helpers.js'),
   { version } = require('../package.json');
 
 // === title ===

--- a/pkg/check.js
+++ b/pkg/check.js
@@ -8,12 +8,10 @@
 
 const fs = require('fs-extra'),
   path = require('path'),
-  { getNotionResources } = require('./helpers.js'),
   { version } = require('../package.json');
 
-module.exports = async function () {
-  const __notion = getNotionResources(),
-    resolvePath = (filepath) => path.resolve(`${__notion}/${filepath}`),
+module.exports = async function ({ __notion }) {
+  const resolvePath = (filepath) => path.resolve(`${__notion}/${filepath}`),
     pathExists = (filepath) => fs.pathExists(resolvePath(filepath)),
     version_path = 'app/ENHANCER_VERSION.txt',
     packed = await pathExists('app.asar.bak');

--- a/pkg/helpers.js
+++ b/pkg/helpers.js
@@ -8,8 +8,7 @@
 
 const os = require('os'),
   path = require('path'),
-  fs = require('fs-extra'),
-  { execSync } = require('child_process');
+  fs = require('fs-extra');
 
 // used to differentiate between "enhancer failed" and "code broken" errors.
 class EnhancerError extends Error {
@@ -22,35 +21,26 @@ class EnhancerError extends Error {
 // checks if being run on the windows subsystem for linux:
 // used to modify windows notion app.
 const is_wsl =
-    process.platform === 'linux' &&
-    os.release().toLowerCase().includes('microsoft'),
-  // ~/.notion-enhancer absolute path.
-  __data = path.resolve(
-    `${
-      is_wsl
-        ? (() => {
-            const stdout = execSync('cmd.exe /c echo %systemdrive%%homepath%', {
-                encoding: 'utf8',
-              }),
-              drive = stdout[0];
-            return `/mnt/${drive.toLowerCase()}${stdout
-              .replace(/\\/g, '/')
-              .slice(2)
-              .trim()}`;
-          })()
-        : os.homedir()
-    }/.notion-enhancer`
-  );
+  process.platform === 'linux' &&
+  os.release().toLowerCase().includes('microsoft');
 
-// transform a wsl filepath to its relative windows filepath if necessary.
-function realpath(hack_path) {
-  if (!is_wsl) return hack_path.replace(/\\/g, '/');
-  hack_path = fs.realpathSync(hack_path);
-  if (hack_path.startsWith('/mnt/')) {
-    hack_path = `${hack_path[5].toUpperCase()}:${hack_path.slice(6)}`;
-  } else hack_path = `//wsl$/${process.env.WSL_DISTRO_NAME}${hack_path}`;
-  return hack_path;
-}
+// ~/.notion-enhancer absolute path.
+const __data = path.resolve(
+  `${
+    is_wsl
+      ? (() => {
+          const stdout = execSync('cmd.exe /c echo %systemdrive%%homepath%', {
+              encoding: 'utf8',
+            }),
+            drive = stdout[0];
+          return `/mnt/${drive.toLowerCase()}${stdout
+            .replace(/\\/g, '/')
+            .slice(2)
+            .trim()}`;
+        })()
+      : os.homedir()
+  }/.notion-enhancer`
+);
 
 // gets system notion app filepath.
 function getNotionResources() {
@@ -159,9 +149,7 @@ function createElement(html) {
 
 module.exports = {
   EnhancerError,
-  is_wsl,
   __data,
-  realpath,
   getNotionResources,
   getEnhancements,
   getJSON,

--- a/pkg/helpers.js
+++ b/pkg/helpers.js
@@ -52,39 +52,14 @@ function realpath(hack_path) {
   return hack_path;
 }
 
-// gets possible system notion app filepaths.
+// gets system notion app filepath.
 function getNotionResources() {
-  let folder = '';
-  switch (process.platform) {
-    case 'darwin':
-      folder = '/Applications/Notion.app/Contents/Resources';
-      break;
-    case 'win32':
-      folder = process.env.LOCALAPPDATA + '\\Programs\\Notion\\resources';
-      break;
-    case 'linux':
-      if (is_wsl) {
-        const stdout = execSync('cmd.exe /c echo %localappdata%', {
-            encoding: 'utf8',
-          }),
-          drive = stdout[0];
-        folder = `/mnt/${drive.toLowerCase()}${stdout
-          .replace(/\\/g, '/')
-          .slice(2)
-          .trim()}/Programs/Notion/resources`;
-      } else {
-        for (let loc of [
-          '/usr/lib/notion-desktop/resources', // https://github.com/davidbailey00/notion-deb-builder/
-          '/opt/notion-app', // https://aur.archlinux.org/packages/notion-app/
-          '/opt/notion', // https://github.com/jaredallard/notion-app
-        ]) {
-          if (fs.pathExistsSync(loc)) folder = loc;
-        }
-      }
-  }
-  if (!folder)
-    throw new EnhancerError('nothing found: platform not supported.');
-  return folder;
+  // __dirname: pkg
+  // __dirname/..: notion-enhancer
+  // __dirname/../..: node_modules
+  // __dirname/../../..: app
+  // __dirname/../../../..: resources
+  return path.resolve(__dirname + '/../../../..');
 }
 
 // lists/fetches all available extensions + themes

--- a/pkg/helpers.md
+++ b/pkg/helpers.md
@@ -20,39 +20,11 @@ but is not caused by faulty programming: e.g. if a file that is known to exist c
 ---
 
 ```js
-const is_wsl;
-```
-
-use `helpers.is_wsl` to check if the enhancer was run from the windows subsystem for linux.
-
-primarily used for internal handling of filepaths (e.g. in the `helpers.realpath` function).
-
----
-
-```js
 const __data;
 ```
 
 use `helpers.__data` to get the absolute path of the directory configuration
 data is saved to by the enhancer.
-
-if used immediately after being accessed, it should always work. however, if fetching its value during enhancement
-and then inserting it into something that will not be executed until the app is opened, it must be put through
-`helpers.realpath` before insertion.
-
----
-
-```js
-function realpath(hack_path) {
-  return runtime_path;
-}
-```
-
-use `helpers.realpath(hack_path)` to transform a path valid at enhancement time into one valid when the app is opened.
-this is particularly useful for wsl compatibility, so every filepath that is fetched during enhancement
-and then inserted into something that will not be executed until the app is opened should be put through this.
-
-primarily used for internal handling of filepaths (e.g. for the modloader).
 
 ---
 
@@ -65,10 +37,6 @@ function getNotionResources() {
 use `helpers.getNotionResources()` to get the absolute path of the notion app parent folder.
 
 primarily used for internal modding of the app (e.g. to apply the modloader and patch launch scripts).
-
-if used immediately after being accessed, it should always work. however, if fetching its value during enhancement
-and then inserting it into something that will not be executed until the app is opened, it must be put through
-`helpers.realpath` before insertion.
 
 ---
 

--- a/pkg/remove.js
+++ b/pkg/remove.js
@@ -8,7 +8,7 @@
 
 const fs = require('fs-extra'),
   path = require('path'),
-  { readline, getNotionResources, __data } = require('./helpers.js');
+  { readline, __data } = require('./helpers.js');
 
 // === title ===
 //  ...information
@@ -18,10 +18,13 @@ const fs = require('fs-extra'),
 //  ~~ exit
 // ### error ###
 
-module.exports = async function ({ delete_data, friendly_errors } = {}) {
+module.exports = async function ({
+  __notion,
+  delete_data,
+  friendly_errors,
+} = {}) {
   try {
-    const __notion = getNotionResources(),
-      check_app = await require('./check.js')();
+    const check_app = await require('./check.js')({ __notion });
     // extracted asar: modded
     if (check_app.code > 1 && check_app.executable) {
       console.info(` ...removing enhancements`);


### PR DESCRIPTION
**[View changes without whitespace (recommended due to some reindentation)](https://github.com/notion-enhancer/notion-enhancer/pull/332/files?w=1)**

This PR lays the groundwork for #321 by removing the need to keep `notion-enhancer` globally installed, and allowing Notion to run in isolation from this global installation. Here are the changes I've made to achieve this:

- Remove auto installation/removal package scripts
- Drop support for auto detecting `resources` folder in favour of passing this explicitly
- Copy `notion-enhancer` to Notion's `node_modules` as part of installation
- Require `notion-enhancer` directly from `node_modules` when patching scripts rather than specifying full path
- Remove all calls to `getNotionResources` during installation/removal
- Replace existing `getNotionResources` function with simpler function to traverse up the folder tree
- Remove some unused helpers now that `getNotionResources` is simpler
- Some other bits of refactoring

Possible further steps for this PR:

- [ ] Refactor out remaining calls to `getNotionResources` from mods, as these can now be achieved with relative paths
- [ ] Re-add support for auto installation by re-implementing the original `getNotionResources` as a new function with a different name (or keep the same name if the above step is also done, since there will no longer be a need for separate functions)

Installation can be achieved on macOS using the following command:

```sh
notion-enhancer apply /Applications/Notion.app/Contents/Resources
```

I haven't yet tested with `notion-deb-builder` but that will be my next step :)