### PR TITLE
pinky boom theme: make the title lowercase

### DIFF
--- a/mods/pinky-boom-light/mod.js
+++ b/mods/pinky-boom-light/mod.js
@@ -8,7 +8,7 @@
 
 module.exports = {
     id: "fbef391c-58ff-4938-bd45-b85ae0435e4e",
-    name: "Pinky Boom Theme",
+    name: "pinky boom theme",
     tags: ['theme', 'light', 'pink'],
     desc: "pinkify your light theme",
     version: "1.0.0",


### PR DESCRIPTION
**problem:** the title of all other modules in the enhancer is in lowercase. we must keep this culture consistent.

<table border="0">
 <tr>
    <td><i>before</i></td>
    <td><i>after</i></td>
 </tr>
 <tr>
    <td><img alt="before" src="https://i.imgur.com/HX3nFtH.png"></td>
    <td><img alt="after" src="https://i.imgur.com/9F5GEuM.png"></td>
 </tr>
</table>