### PR TITLE
restore messenger emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ on top of other windows even if it's not focused.
 
 **author:** [dragonwocky](https://github.com/dragonwocky/)
 
-| option | type   | values/defaults                                                                                                 |
-| ------ | ------ | --------------------------------------------------------------------------------------------------------------- |
-| style  | select | twitter, apple, google, microsoft, samsung, whatsapp, facebook, joypixels, openmoji, emojidex, lg, htc, mozilla |
+| option | type   | values/defaults                                                                                                            |
+| ------ | ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| style  | select | twitter, apple, google, microsoft, samsung, whatsapp, facebook, messenger, joypixels, openmoji, emojidex, lg, htc, mozilla |
 
 ![](https://user-images.githubusercontent.com/16874139/97820652-3f5b7d80-1d03-11eb-80a6-34089b946711.png)
 

--- a/mods/emoji-sets/mod.js
+++ b/mods/emoji-sets/mod.js
@@ -26,6 +26,7 @@ module.exports = {
         'samsung',
         'whatsapp',
         'facebook',
+        'messenger',
         'joypixels',
         'openmoji',
         'emojidex',


### PR DESCRIPTION
Adding Messenger emojis removed in [v0.10.2](https://github.com/notion-enhancer/notion-enhancer/commit/8f1612e43cd6d4eb5603c62d1033cb137cb4a923) back to emoji sets extension. The [issue](https://github.com/benborgers/emojicdn/issues/5) with the provider is solved, so the emojis are available now.