### PR TITLE
Add support for user-only Notion installs on macOS

### DIFF
--- a/pkg/helpers.js
+++ b/pkg/helpers.js
@@ -57,7 +57,12 @@ function getNotionResources() {
   let folder = '';
   switch (process.platform) {
     case 'darwin':
-      folder = '/Applications/Notion.app/Contents/Resources';
+      for (let loc of [
+        `/Users/${process.env.USER}/Applications/Notion.app/Contents/Resources`, // Notion is installed only for the current user
+        '/Applications/Notion.app/Contents/Resources' // Notion is installed globally
+      ]) {
+        if (fs.pathExistsSync(loc)) folder = loc;
+      }
       break;
     case 'win32':
       folder = process.env.LOCALAPPDATA + '\\Programs\\Notion\\resources';

--- a/pkg/helpers.js
+++ b/pkg/helpers.js
@@ -11,7 +11,7 @@ const os = require('os'),
   fs = require('fs-extra'),
   { execSync } = require('child_process');
 
-// used to differentiate between "enhancer failed' and "code broken" errors.
+// used to differentiate between "enhancer failed" and "code broken" errors.
 class EnhancerError extends Error {
   constructor(message) {
     super(message);


### PR DESCRIPTION
This should allow the enhancer to work with the standard macOS Notion install location (`/Applications/Notion.app`) and the local user install location (`~/Applications/Notion.app`). I have tested this on my current machine and everything appears to be working!