### PR TITLE
Fix margins for every emoji set

### DIFF
--- a/mods/emoji-sets/app.css
+++ b/mods/emoji-sets/app.css
@@ -1,0 +1,11 @@
+/*
+ * emoji sets
+ * (c) 2020 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
+ * (c) this css fix was provided by Arecsu from martyr⁠— (https://martyr.shop/)
+ * under the MIT license
+ */
+
+div.notion-record-icon [style*='Apple Color Emoji'] {
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
Custom emojis, when displayed as icons in every page and in the left sidebar of Notion, are a bit misaligned. This is not the case for the emojis in the page content. Just specific places when they act like icons. They are a few pixels off but it triggers an OCD in me 🤣

This fixes it and it looks awesome. Precisely aligned as the default emoji set.